### PR TITLE
Update App.svelte

### DIFF
--- a/documentation/examples/06-lifecycle/02-update/App.svelte
+++ b/documentation/examples/06-lifecycle/02-update/App.svelte
@@ -89,6 +89,7 @@
 	}
 
 	span {
+		color:black;
 		padding: 0.5em 1em;
 		display: inline-block;
 	}


### PR DESCRIPTION
Added CSS color property to span tag, which was missing before which cause less visibility of text in dark mode now its look greater 

Before :
![image](https://github.com/prajapatiomkar/svelte/assets/72141037/7380b0be-5c1a-4846-90b0-095f0fdd2c9a)

After :
![image](https://github.com/prajapatiomkar/svelte/assets/72141037/7035f3d2-14ea-4666-bfec-9f64a1da1c7c)
